### PR TITLE
Replace webpackConfig "args" with "arguments" in config file template

### DIFF
--- a/src/cli/init-config/config.js.template.hbs
+++ b/src/cli/init-config/config.js.template.hbs
@@ -333,7 +333,7 @@ module.exports = {
        to dependency-cruiser's current working directory. When not provided defaults
        to './webpack.conf.js'.
 
-       The (optional) `env` and `args` attributes contain the parameters to be passed if
+       The (optional) `env` and `arguments` attributes contain the parameters to be passed if
        your webpack config is a function and takes them (see webpack documentation
        for details)
      */
@@ -341,13 +341,13 @@ module.exports = {
     webpackConfig: {
       fileName: '{{webpackConfig}}',
       // env: {},
-      // args: {},
+      // arguments: {},
     },
     {{^}}
     // webpackConfig: {
     //  fileName: './webpack.config.js',
     //  env: {},
-    //  args: {},
+    //  arguments: {},
     // },
     {{/if}}
 


### PR DESCRIPTION
## Description

Changed the use of `args` to `arguments` in the config JS file template in the context of the `options.webpackConfig` section.

## Motivation and Context

Our webpack config exports a function that relies on the second parameter to retrieve the `mode` (e.g. `'production'`). So I customized the generated config file to set `options.webpackConfig.args` to `{ mode: 'production' }`. When I attempted to run `dependency-cruiser` using it, I got a `TypeError` about trying to access the `mode` property on a null value. When I logged out the values, I saw that the second value was indeed coming in as null. So I looked in the code to see where it was reading the `webpackConfig` settings and found that the correct property name was `arguments`, not `args`.

So I figured I would update the template that generates the config so that others don't get stuck like I did.

## How Has This Been Tested?

I haven't, to be honest, since it was simple text changes to a template file.

- [ ] green ci

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
